### PR TITLE
Added cython to prevent breaking thriftpy on python3.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # beautifulsoup4
 # django
+cython
 django-appconf
 # django-compressor
 django-environ


### PR DESCRIPTION
While installation, one indirect dependency package `thriftpy` breaks for `python3.7`. 
Adding `cython` fixes the build error for the same package and allows the installation to go through.

Check out [ISSUE-37](https://github.com/eleme/thriftpy/issues/333) for `thriftpy`